### PR TITLE
Tanzania ctca 3dl tumshukuru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ Temporary Items
 .DS_Store
 system/data_tasks/sample_notebook.html
 user/test_file.json
+config.json

--- a/system/dashboards/components/hei/datasets.3dl
+++ b/system/dashboards/components/hei/datasets.3dl
@@ -8,7 +8,7 @@
                 name="hei_not_registered_data"
                 queryName="hei/table/not_registered"
                 pageSize="15"
-                searchColumns="Patient ID, DOB, Age in Months, Sex, Infant Status, Exposed Infant Number"
+                searchColumns="Patient ID, Date of Birth, HEI Current Age in Months, Sex, Infant Status, Exposed Infant ID"
                 filterFrom="gender"
             />
 
@@ -24,7 +24,7 @@
                 name="hei_needing_eid_test_data"
                 queryName="hei/table/needing_eid_test"
                 pageSize="15"
-                searchColumns="Patient ID, DOB, Age in Months, Sex, Last EID Visit Date, Exposed Infant Number"
+                searchColumns="Patient ID, Date of Birth, HEI Current Age in Months, Sex, Last EID Visit Date, Exposed Infant ID"
                 filterFrom="gender"
             />
 
@@ -40,7 +40,7 @@
                 name="hei_without_fo_data"
                 queryName="hei/table/without_fo"
                 pageSize="15"
-                searchColumns="Patient ID, DOB, Age in Months, Sex, Exposed Infant Number"
+                searchColumns="Patient ID, Date of Birth, HEI Current Age in Months, Sex, Exposed Infant ID"
                 filterFrom="gender"
             />
 
@@ -56,7 +56,7 @@
                 name="hei_pos_not_initiated_data"
                 queryName="hei/table/pos_not_initiated"
                 pageSize="15"
-                searchColumns="Patient ID, DOB, Age in Months, Sex, Last Antibody Result, Exposed Infant Number"
+                searchColumns="Patient ID, Date of Birth, HEI Current Age in Months, Sex, Last Antibody Result, Exposed Infant ID"
                 filterFrom="gender"
             />
 

--- a/system/dashboards/components/hei/overview.3dl
+++ b/system/dashboards/components/hei/overview.3dl
@@ -12,11 +12,11 @@
         </Table>
         </Tile>
 
-        <Tile data="tile_hei_needing_eid_test_data" title="Needing EID Test">
+        <Tile data="tile_hei_needing_eid_test_data" title="HEI Missed EID test <2 Months">
             <Table
                 data="hei_needing_eid_test_data"
                 exportData="true"
-                header="HEI Needing EID Test"
+                header="HEI Missed EID test <2 Months"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >

--- a/system/dashboards/components/hei/overview.3dl
+++ b/system/dashboards/components/hei/overview.3dl
@@ -12,7 +12,7 @@
         </Table>
         </Tile>
 
-        <Tile data="tile_hei_needing_eid_test_data" title="HEI Missed EID test <2 Months">
+        <Tile data="tile_hei_needing_eid_test_data" title="Missed EID test <2 Months">
             <Table
                 data="hei_needing_eid_test_data"
                 exportData="true"
@@ -36,7 +36,7 @@
         </Table>
         </Tile>
 
-        <Tile data="tile_hei_pos_not_initiated_data" title="POS Not Initiated">
+        <Tile data="tile_hei_pos_not_initiated_data" title="HEI_Pos not on ART">
             <Table
                 data="hei_pos_not_initiated_data"
                 exportData="true"

--- a/system/dashboards/hei.3dl
+++ b/system/dashboards/hei.3dl
@@ -18,7 +18,7 @@
         data="report_week_data"
         tabName="B. Not Registered"
         title="HEI Not Registered"
-        subTitle="Table of HEI clients who are not registered."
+        subTitle="Table of HEI who were born last week but not registered "
         lastRefresh="Data as at %report_week_dates%"
     >
         <Grid>
@@ -26,7 +26,7 @@
                 data="hei_not_registered_data"
                 exportData="true"
                 header="HEI Not Registered"
-                subHeader="Table of HEI clients who are not registered."
+                subHeader="Table of HEI who were born last week but not registered."
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >
@@ -37,8 +37,8 @@
 
     <Dashboard
         data="report_week_data"
-        tabName="C. Needing EID Test"
-        title="HEI Needing EID Test"
+        tabName="C. HEI Missed EID test <2 Months"
+        title="HEI Missed EID test <2 Months"
         subTitle="Table of HEI clients requiring EID Test."
         lastRefresh="Data as at %report_week_dates%"
     >
@@ -46,7 +46,7 @@
             <Table
                 data="hei_needing_eid_test_data"
                 exportData="true"
-                header="HEI Needing EID Test"
+                header="HEI Missed EID test <2 Months"
                 subHeader="Table of HEI clients requiring EID Test."
                 variant="plain"
                 detailsViewColumn="Patient ID"

--- a/system/dashboards/hei.3dl
+++ b/system/dashboards/hei.3dl
@@ -66,6 +66,7 @@
         <Grid>
             <Table
                 data="hei_without_fo_data"
+                exportData="true"
                 header="Clients Who Missed Viral Load"
                 subHeader="Table of HEI clients without final outcome."
                 variant="plain"
@@ -86,6 +87,7 @@
         <Grid>
             <Table
                 data="hei_pos_not_initiated_data"
+                exportData="true"
                 header="Clients with Unsupppressed VL"
                 subHeader="Table of HEI_POS clients who are not initiated on ART."
                 variant="plain"

--- a/system/dashboards/hei.3dl
+++ b/system/dashboards/hei.3dl
@@ -37,7 +37,7 @@
 
     <Dashboard
         data="report_week_data"
-        tabName="C. HEI Missed EID test <2 Months"
+        tabName="C. Missed EID test <2 Months"
         title="HEI Missed EID test <2 Months"
         subTitle="Table of HEI clients requiring EID Test."
         lastRefresh="Data as at %report_week_dates%"
@@ -58,7 +58,7 @@
 
     <Dashboard
         data="report_week_data"
-        tabName="D. Without FO"
+        tabName="D. 18-24 Months Without FO"
         title="HEI 18-24 Months Without FO"
         subTitle="Table of HEI clients without final outcome."
         lastRefresh="Data as at %report_week_dates%"
@@ -78,7 +78,7 @@
 
     <Dashboard
         data="report_week_data"
-        tabName="E. Not Initiated"
+        tabName="E. HEI_Pos not on ART"
         title="HEI_POS Not Initiated on ART"
         subTitle="Table of HEI_POS clients who are not initiated on ART."
         lastRefresh="Data as at %report_week_dates%"

--- a/system/dashboards/home.3dl
+++ b/system/dashboards/home.3dl
@@ -26,6 +26,7 @@
                 data="missed_appointment_clients_data"
                 header="Clients With Missed Appointments"
                 subHeader="Table of clients missed appointments last week."
+                exportData="true"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >
@@ -46,6 +47,7 @@
                 data="need_vl_clients_data"
                 header="Clients Who Missed Viral Load Test"
                 subHeader="Table of clients who missed viral load test."
+                exportData="true"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >
@@ -66,6 +68,7 @@
                 data="unsuppressed_clients_data"
                 header="Unsuppressed Clients Not Initiated on EAC"
                 subHeader="Table of clients with appointments last week whose viral load is unsuppressed and are not initiated on EAC."
+                exportData="true"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >
@@ -87,6 +90,7 @@
                 exportData="true"
                 header="hildren Living with HIV (CLHIV) Nutrition Challenges"
                 subHeader="Table of CLHIV who had appointmnet last week but had no documentation of either height/length or weight, or misclassification of nutritional status."
+                exportData="true"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >
@@ -108,6 +112,7 @@
                 exportData="true"
                 header="AHD Suspect Clients"
                 subHeader="Table of clients without a CrAg test, confirmed as Advanced HIV Disease (AHD) suspects."
+                exportData="true"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >
@@ -129,6 +134,7 @@
                 exportData="true"
                 header="Clients with Confirmed AHD and no Management"
                 subHeader="Table of confirmed AHD clients with positive CrAg test and no follow-up for prophylaxis or treatment."
+                exportData="true"
                 variant="plain"
                 detailsViewColumn="Patient ID"
             >

--- a/system/dashboards/sql/hei/table/needing_eid_test.sql
+++ b/system/dashboards/sql/hei/table/needing_eid_test.sql
@@ -1,12 +1,15 @@
 SELECT
-    [Patient ID],
-    [Exposed Infant Number],
-    [Child Patient ID],
+    [Patient ID] AS [Mother Patient ID],
+    [Exposed Infant ID],
+    [Date of Birth],
+    [HEI Age in Weeks at Last Visit],
     [Sex],
-    [DOB],
-    [Age in Months],
-    [Last EID Visit Date],
-    [Eligible for First EID Test]
+    [Last Visit Date],
+    [Documented Risk Category],
+	[HEI Eligible for DNA PCR at Birth],
+	[DNA PCR at Birth Sample Collection Date],
+    [HEI Eligible for DNA PCR at 4 to 6 Weeks],
+	[DNA PCR at 4 to 6 Weeks Sample Collection Date]
 FROM
     duft.fact_duft_hei_sentinel_event
 WHERE

--- a/system/dashboards/sql/hei/table/not_registered.sql
+++ b/system/dashboards/sql/hei/table/not_registered.sql
@@ -1,15 +1,7 @@
 SELECT
-    [Patient ID],
-    [Exposed Infant Number],
-    [Child Patient ID],
-    [Sex],
-    [DOB],
-    [Age in Months],
+    [Patient ID] AS [Mother Patient ID],
     [Due Date],
-    [Delivery Date],
-    [First Visit Date After Delivery],
-    [HEI Registered],
-    [Infant Status]
+    [Delivery Date] AS [Date of Delivery]
 FROM
     duft.fact_duft_hei_sentinel_event
 WHERE

--- a/system/dashboards/sql/hei/table/not_registered.sql
+++ b/system/dashboards/sql/hei/table/not_registered.sql
@@ -1,7 +1,11 @@
 SELECT
     [Patient ID] AS [Mother Patient ID],
+    [Mother's Age],
+    [Date Start ART],
+    [Last Visit Date],
     [Due Date],
-    [Delivery Date] AS [Date of Delivery]
+    [Date of Delivery],
+    [HEI Current Age in Weeks]
 FROM
     duft.fact_duft_hei_sentinel_event
 WHERE

--- a/system/dashboards/sql/hei/table/without_fo.sql
+++ b/system/dashboards/sql/hei/table/without_fo.sql
@@ -6,9 +6,9 @@ SELECT
     [Sex],
     [Last Visit Date],
     [DNA PCR Test Results at Birth],
-    [DNA PCR Test Results at 4-6 Weeks],
+    [DNA PCR Test Results at 4 to 6 Weeks],
     [DNA PCR Test Results at 9 Months],
-    [Antibody Test Results 3 Months Post-BF]
+    [Antibody Test Results at 3 Months Post-BF]
     FROM
     duft.fact_duft_hei_sentinel_event
 WHERE

--- a/system/dashboards/sql/hei/table/without_fo.sql
+++ b/system/dashboards/sql/hei/table/without_fo.sql
@@ -1,17 +1,20 @@
 SELECT
-    [Patient ID],
-    [Exposed Infant Number],
-    [Child Patient ID],
+    [Patient ID] AS [Mother Patient ID],
+    [Exposed Infant ID],
+    [Date of Birth],
+    [HEI Current Age in Months],
     [Sex],
-    [DOB],
-    [Age in Months],
-    [Has Final Outcome]
-FROM
+    [Last Visit Date],
+    [DNA PCR Test Results at Birth],
+    [DNA PCR Test Results at 4-6 Weeks],
+    [DNA PCR Test Results at 9 Months],
+    [Antibody Test Results 3 Months Post-BF]
+    FROM
     duft.fact_duft_hei_sentinel_event
 WHERE
     [Has Final Outcome] = 'No'
 AND
-    [Age in Months] BETWEEN 18 AND 24
+    [HEI Current Age in Months] BETWEEN 18 AND 24
 AND
     ISNULL([Infant Status], '') NOT IN ('TRN', 'DIE')
 ORDER BY

--- a/system/dashboards/sql/hei/tile/needing_eid_test.sql
+++ b/system/dashboards/sql/hei/tile/needing_eid_test.sql
@@ -1,1 +1,3 @@
-SELECT COUNT(*) FROM duft.fact_duft_hei_sentinel_event WHERE [Eligible for First EID Test] = 'Yes' AND ISNULL([Infant Status], '') NOT IN ('TRN', 'DIE')
+SELECT COUNT(*) 
+    FROM duft.fact_duft_hei_sentinel_event 
+WHERE [Eligible for First EID Test] = 'Yes' AND ISNULL([Infant Status], '') NOT IN ('TRN', 'DIE')

--- a/system/dashboards/sql/hei/tile/not_registered.sql
+++ b/system/dashboards/sql/hei/tile/not_registered.sql
@@ -1,1 +1,3 @@
-SELECT COUNT(*) FROM duft.fact_duft_hei_sentinel_event WHERE [HEI Registered] = 'No' AND ISNULL([Infant Status], '') NOT IN ('TRN', 'DIE')
+SELECT COUNT(*) 
+ FROM duft.fact_duft_hei_sentinel_event 
+WHERE [HEI Registered] = 'No' AND ISNULL([Infant Status], '') NOT IN ('TRN', 'DIE')

--- a/system/dashboards/sql/hei/tile/pos_not_initiated.sql
+++ b/system/dashboards/sql/hei/tile/pos_not_initiated.sql
@@ -1,1 +1,3 @@
-SELECT COUNT(*) FROM duft.fact_duft_hei_sentinel_event WHERE [Last Antibody Result] = 'POS'
+SELECT COUNT(*) 
+    FROM duft.fact_duft_hei_sentinel_event
+WHERE [Last Antibody Result] = 'POS'

--- a/system/dashboards/sql/hei/tile/without_fo.sql
+++ b/system/dashboards/sql/hei/tile/without_fo.sql
@@ -1,1 +1,6 @@
-SELECT COUNT(*) FROM duft.fact_duft_hei_sentinel_event WHERE [Has Final Outcome] = 'No' AND [Age in Months] BETWEEN 18 AND 24 AND ISNULL ([Infant Status], '') NOT IN ('TRN', 'DIE')
+SELECT 
+    COUNT(*) 
+FROM 
+    duft.fact_duft_hei_sentinel_event 
+WHERE [Has Final Outcome] = 'No' 
+AND [HEI Current Age in Months] BETWEEN 18 AND 24 AND ISNULL ([Infant Status], '') NOT IN ('TRN', 'DIE')


### PR DESCRIPTION
This PR includes a series of maintenance updates and refinements to the HEI (HIV-Exposed Infants) dashboards and related SQL code, focusing on column naming consistency, formatting, and export features.

### Key Updates:
- Renamed and standardized columns related to HEI not registered, HEI Missed EID test <2 Months, HEI 18-24 Months without FO, and Overview.
- Added new HEI columns, and fixed those with inline number as name like (4-6) being (4 to 6) to avoid conflicting.
- Updated SQL tile formatting for improved readability and maintainability.
- Modified the HEI export feature logic for clarity and alignment with updated columns.
- Enhanced search datasets and dashboard headers/titles.
