### PR TITLE
Add Proof-of-Concept Map for DHIS2 Data Visualization

### DIFF
--- a/system/dashboards/dhis2.3dl
+++ b/system/dashboards/dhis2.3dl
@@ -13,7 +13,6 @@
     </Datasets>
 
     <Dashboard
-        data="dhis2_data"
         tabName="DHIS2"
         title="Sample DHIS2 data from a sql view"
     >

--- a/system/dashboards/dhis2.3dl
+++ b/system/dashboards/dhis2.3dl
@@ -5,6 +5,11 @@
             endPoint="/sqlViews/w3UxFykyHFy/data.json"
             method="GET"
         />
+        <DHIS2Data
+            name = "dhis2_facility_data"
+            endPoint="/sqlViews/dI68mLkP1wN/data.json"
+            method="GET"
+        />
     </Datasets>
 
     <Dashboard
@@ -13,9 +18,14 @@
         title="Sample DHIS2 data from a sql view"
         subTitle="Table of DHIS2 data."
     >
-        <Grid> 
-            <Table data ="dhis_data"/>
-            <LineChart data="dhis_data" />
+        <Grid>
+            <Row columns="1" largeColumns="1">
+                <Table data ="dhis_data"/>
+            </Row>
+            <Row  largeColumns="2" columns="2"> 
+                <ClusterMap data ="dhis2_facility_data"/>
+                <Table data="dhis2_facility_data"/>
+            </Row>
         </Grid>
     </Dashboard>
 </Dashboards>

--- a/system/dashboards/dhis2.3dl
+++ b/system/dashboards/dhis2.3dl
@@ -16,15 +16,20 @@
         data="dhis2_data"
         tabName="DHIS2"
         title="Sample DHIS2 data from a sql view"
-        subTitle="Table of DHIS2 data."
     >
         <Grid>
             <Row columns="1" largeColumns="1">
-                <Table data ="dhis_data"/>
+                <Table 
+                header="DHIS2 Organisation Units"
+                subHeader="A table to demo dhis2 data" 
+                data ="dhis_data"/>
             </Row>
             <Row  largeColumns="2" columns="2"> 
                 <ClusterMap data ="dhis2_facility_data"/>
-                <Table data="dhis2_facility_data"/>
+                <Table 
+                header="DHIS2 Organisation Units Coordinates"
+                subHeader="A table to demo dhis2 data"
+                data="dhis2_facility_data"/>
             </Row>
         </Grid>
     </Dashboard>

--- a/system/dashboards/map.3dl
+++ b/system/dashboards/map.3dl
@@ -38,5 +38,22 @@
             />
         </Grid>
     </Dashboard>
+    <Dashboard
+        data="map_data"
+        tabName="MAP 2"
+        title="Sample map"
+        subTitle="cluster map"
+    >
+        <Filters>
+            <Filter caption="Facility Type" name="facility_type" data="facility_type_data" />
+            <Filter caption="Keph Level" name="keph_level" data="keph_level_data" />
+            <Filter caption="Operational Status" name="operational_status" data="operational_status_data" />
+        </Filters>
+        <Grid> 
+            <HeatMap
+             data = "initiated_detailed_data"
+            />
+        </Grid>
+    </Dashboard>
 </Dashboards>
         


### PR DESCRIPTION
![Image 29-04-2025 at 10 23](https://github.com/user-attachments/assets/332d15c1-ef0a-46e7-b9e4-d8cf7252718d)
![Image 29-04-2025 at 10 23](https://github.com/user-attachments/assets/1c1e3415-1d42-4d73-ab98-71015cdce43c)

This PR adds a map visualization to demonstrate that DHIS2 data can be effectively visualized within our platform. Due to the limitations of using a demo DHIS2 instance, I was unable to include additional or more relevant data at this stage.

However, when working with country-specific DHIS2 instances, we will be able to retrieve more targeted data through SQL views tailored to each implementation. While DHIS2 itself does not support visualizing SQL view data directly on its dashboards, this is exactly the gap that DUFT is designed to fill—allowing us to render rich, customized visualizations using this data.